### PR TITLE
verbetering: terug naar standaardinstellingen veranderde niet de kleu…

### DIFF
--- a/javascripts/job-module/job-module.js
+++ b/javascripts/job-module/job-module.js
@@ -341,7 +341,11 @@ JobModuleForm.prototype.setToDefault = function(e) {
         document.getElementById(elementId + 'white').checked = true;
         continue;
       }
-      document.getElementById(elementId).value = this.defaultValues[elementId];
+      if(document.getElementById(elementId).color) {
+        document.getElementById(elementId).color.fromString(this.defaultValues[elementId]);
+      } else {
+        document.getElementById(elementId).value = this.defaultValues[elementId];
+      }
     }
     var designform = document.getElementsByName('designform')[0];
     designform.action = '#designform';


### PR DESCRIPTION
…r van de velden als de url niet veranderd hoefde te worden. Nu library op de juiste manier gebruikt zodat het wel kan.

Test Plan: Ga naar vacaturemodule-stap-twee.html en druk op toon module. Verander hierna wat opmaak en druk dan NIET op toon module maar op "terug naar standaardinstellingen".

Reviewers: claassen, #uitzendbureau.nl

Reviewed By: claassen, #uitzendbureau.nl

Differential Revision: http://phabricator.uzbdev.nl/D762
